### PR TITLE
change regex to fix the drawhook location

### DIFF
--- a/script.js
+++ b/script.js
@@ -229,7 +229,7 @@
     }
 
 
-    var regpattern = /(drawGeometry:\s*function\([^\(\{]*\{)[^]*getInstanceID/;
+    var regpattern = /(drawGeometry:\s*function\(\)\{.*e\s*=\s*t.getLastProgramApplied\(\);)/;
 
     window.allmodel = [];
     window.drawhook = function(obj) {


### PR DESCRIPTION
there's a returned function where `this` is the object we want, I moved the `window.drawhook(this)` into that function and the script seems to work now, i got a bunch of `.obj`s that load properly in fusion 360